### PR TITLE
Removes unused routes from comments controller

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@
 
 Spree::Core::Engine.add_routes do
   namespace :admin do
-    resources :comments
+    resources :comments, only: [:create, :update, :destroy]
     resources :comment_types
 
     resources :orders do


### PR DESCRIPTION
None of the comments views for show, new, edit, or index are
implemented, so these will error if you try and go to them.

Given the way this gem is used, none of those are currently
required.

Fixes #4 
