### PR TITLE
Removes shipments controller and routes

### DIFF
--- a/app/controllers/spree/admin/shipments_controller_decorator.rb
+++ b/app/controllers/spree/admin/shipments_controller_decorator.rb
@@ -1,6 +1,0 @@
-Spree::Api::ShipmentsController.class_eval do
-  def comments
-    shipment
-    @comment_types = Spree::CommentType.where(:applies_to => "Shipment")
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,3 @@
-
-#map.namespace :admin do |admin|
-#  admin.resources :comments
-#  admin.resources :comment_types
-#
-#  admin.resources :orders, :member => {:comments => :get} do |order|
-#    order.resources :shipments, :member => {:comments => :get}
-#  end
-#end
-#
-
 Spree::Core::Engine.add_routes do
   namespace :admin do
     resources :comments
@@ -18,15 +7,6 @@ Spree::Core::Engine.add_routes do
       member do
         get :comments
       end
-
-      resources :shipments do
-        member do
-         get :comments
-       end
-      end
     end
   end
-
-#match '/admin/comments' => 'admin/comments', :via => [:get, :post]
-#  match '/admin/comment_types' => 'admin/comment_types', :via => [:get, :post]
 end


### PR DESCRIPTION
The routes were going to Spree::Admin:ShipmentsController, but that
controller hasn't existed in a few years.

The shipments controller here was a class eval on the
Spree::Api::ShipmentsController, which makes no sense and is not
called from anywhere else.

Fixes #5 
