### PR TITLE
Adds in feature spec for adding comment types

### DIFF
--- a/spec/features/admin/comment_types_spec.rb
+++ b/spec/features/admin/comment_types_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.feature 'Comment Types', :js do
+  before { login_as_admin }
+
+  it 'adds a menu item in settings' do
+    visit spree.edit_admin_general_settings_path
+
+    # uppercase < v1.2, sentence case >= v1.3
+    expect(page).to have_text(/Comment Types/i)
+  end
+
+  it 'adds a new comment type' do
+    visit spree.new_admin_comment_type_path
+
+    fill_in 'Name', with: 'Some name'
+    click_button 'Create'
+
+    expect(page).to have_text('Some name')
+  end
+end


### PR DESCRIPTION
This gets coverage on the comment types stuff. The controller for comments type is a resource controller with no changes, so there are no specs. 

I mostly wanted to make sure the menu links were properly added to settings.
