### PR TITLE
Fix broken button_tag method call

### DIFF
--- a/app/views/spree/admin/comment_types/new.html.erb
+++ b/app/views/spree/admin/comment_types/new.html.erb
@@ -16,7 +16,7 @@
   <fieldset class="no-border-top">
     <%= render :partial => 'form', :locals => { :f => f } %>
     <div data-hook="buttons" class="filter-actions actions">
-      <%= button_tag I18n.t('spree.create'), 'icon-ok' %>
+      <%= button_tag I18n.t('spree.create'), class: 'fa fa-icon-ok button' %>
     </div>
   </fieldset>
 <% end %>


### PR DESCRIPTION
After a refactor the `button_tag` has been introduced in the wrong way in the gem. This fix alone makes the build green.

ref: https://github.com/solidusio-contrib/solidus_comments/issues/22