### PR TITLE
Add permissions check to comments form

### DIFF
--- a/app/views/spree/admin/shared/_comments.html.erb
+++ b/app/views/spree/admin/shared/_comments.html.erb
@@ -6,37 +6,39 @@
   </div>
 <% end %>
 
-<div class="order-add-comment">
-  <%= form_for(:comment, :url => admin_comments_url) do |f| %>
-    <%= hidden_field_tag 'comment[commentable_id]', commentable.id %>
-    <%= hidden_field_tag 'comment[commentable_type]', commentable.class %>
-    <%= hidden_field_tag 'comment[user_id]', spree_current_user.id %>
+<% if can? :create, commentable.comments.build %>
+  <div class="order-add-comment">
+    <%= form_for(:comment, :url => admin_comments_url) do |f| %>
+      <%= hidden_field_tag 'comment[commentable_id]', commentable.id %>
+      <%= hidden_field_tag 'comment[commentable_type]', commentable.class %>
+      <%= hidden_field_tag 'comment[user_id]', spree_current_user.id %>
 
-    <fieldset data-hook="admin_comment_form_fields" class="no-border-top fullwidth">
-      <fieldset class="index no-border-bottom">
-        <legend align="center"><%= I18n.t('spree.add_comment') %></legend>
+      <fieldset data-hook="admin_comment_form_fields" class="no-border-top fullwidth">
+        <fieldset class="index no-border-bottom">
+          <legend align="center"><%= I18n.t('spree.add_comment') %></legend>
 
-        <div data-hook="comment_fields" class="row">
-          <div class="alpha twelve columns">
-            <% if @comment_types.present? %>
+          <div data-hook="comment_fields" class="row">
+            <div class="alpha twelve columns">
+              <% if @comment_types.present? %>
+                <div class="field">
+                  <%= f.label :comment_type_id, I18n.t('spree.type') %>
+                  <%= f.select :comment_type_id, @comment_types.map{|ct| [ct.name, ct.id]},{} ,:class => 'fullwidth' %>
+                </div>
+              <% end %>
               <div class="field">
-                <%= f.label :comment_type_id, I18n.t('spree.type') %>
-                <%= f.select :comment_type_id, @comment_types.map{|ct| [ct.name, ct.id]},{} ,:class => 'fullwidth' %>
+                <%= f.label :comment, I18n.t('spree.comment') %>
+                <%= f.text_area :comment, :style => 'height:150px;', :class => 'fullwidth' %>
               </div>
-            <% end %>
-            <div class="field">
-              <%= f.label :comment, I18n.t('spree.comment') %>
-              <%= f.text_area :comment, :style => 'height:150px;', :class => 'fullwidth' %>
             </div>
           </div>
+        </fieldset>
+
+        <div class="clear"></div>
+
+        <div class="form-buttons filter-actions actions" data-hook="buttons">
+          <%= f.submit I18n.t('spree.add_comment') %>
         </div>
       </fieldset>
-
-      <div class="clear"></div>
-
-      <div class="form-buttons filter-actions actions" data-hook="buttons">
-        <%= f.submit I18n.t('spree.add_comment') %>
-      </div>
-    </fieldset>
-  <% end %>
-</div>
+    <% end %>
+  </div>
+<% end %>

--- a/solidus_comments.gemspec
+++ b/solidus_comments.gemspec
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 Gem::Specification.new do |s|
   s.platform  = Gem::Platform::RUBY
   s.name      = 'solidus_comments'
@@ -6,7 +5,7 @@ Gem::Specification.new do |s|
   s.summary   = 'Adds comments to the solidus admin'
   s.required_ruby_version = '>= 2.1'
 
-  s.author    =  [ 'Rails Dog', 'Solidus Contrib' ]
+  s.author    = ['Rails Dog', 'Solidus Contrib']
   s.email     = 'contact+comments@solidus.io'
   s.homepage  = 'https://github.com/solidusio-contrib/solidus_comments'
 
@@ -16,19 +15,19 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   solidus_version = ['>= 1.0', '< 3']
-  s.add_dependency 'solidus_core', solidus_version
-  s.add_dependency 'solidus_backend', solidus_version
-  s.add_dependency 'solidus_api', solidus_version
-  s.add_dependency 'deface'
 
   s.add_dependency 'acts_as_commentable', '4.0.1'
+  s.add_dependency 'deface'
+  s.add_dependency 'solidus_api', solidus_version
+  s.add_dependency 'solidus_backend', solidus_version
+  s.add_dependency 'solidus_core', solidus_version
 
   s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'capybara-screenshot'
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'poltergeist'
+  s.add_development_dependency 'puma'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'sqlite3', '~> 1.3.6'

--- a/solidus_comments.gemspec
+++ b/solidus_comments.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'capybara', '~> 2.18'
   s.add_development_dependency 'capybara-screenshot'
+  s.add_development_dependency 'chromedriver-helper', '~> 1.2' unless ENV['CI']
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'ffaker'

--- a/spec/features/admin/order_comments_spec.rb
+++ b/spec/features/admin/order_comments_spec.rb
@@ -19,5 +19,43 @@ RSpec.feature 'Order Comments', :js do
     expect(page).to have_text(/Comments \(1\)/i)
     expect(page).to have_text('A test comment.')
   end
+
+  context 'without permission' do
+    let(:comment) { order.comments.new }
+
+    before do
+      # Stub for not allowing user to have comment permissions on the order.
+      # Works with just the default stub for multiple instances.
+      allow_any_instance_of(CanCan::Ability)
+        .to receive(:can?).and_return(false)
+      # Stub normal permissions in order to override create comment permission.
+      allow_any_instance_of(CanCan::Ability)
+        .to receive(:can?).with(:admin, Spree::Order).and_return(true)
+      allow_any_instance_of(CanCan::Ability)
+        .to receive(:can?).with(:comments, Spree::Order).and_return(true)
+      allow_any_instance_of(CanCan::Ability)
+        .to receive(:can?).with(:update, order).and_return(true)
+      allow_any_instance_of(CanCan::Ability)
+        .to receive(:can?).with(:display, Spree::Adjustment).and_return(true)
+      allow_any_instance_of(CanCan::Ability)
+        .to receive(:can?).with(:display, Spree::Payment).and_return(true)
+      allow_any_instance_of(CanCan::Ability)
+        .to receive(:can?)
+        .with(:display, Spree::ReturnAuthorization).and_return(true)
+      allow_any_instance_of(CanCan::Ability)
+        .to receive(:can?)
+        .with(:display, Spree::CustomerReturn).and_return(true)
+      allow_any_instance_of(CanCan::Ability)
+        .to receive(:can?)
+        .with(:manage, Spree::OrderCancellations).and_return(true)
+    end
+
+    it 'should not display form' do
+      visit spree.comments_admin_order_path(order)
+
+      expect(page).to have_text(/No Comments found/i)
+      expect(page).to_not have_text 'Add Comment'
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/features/admin/order_comments_spec.rb
+++ b/spec/features/admin/order_comments_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.feature 'Order Comments', :js do
   let!(:order) { create(:completed_order_with_totals) }
 
@@ -7,14 +8,16 @@ RSpec.feature 'Order Comments', :js do
     login_as_admin
   end
 
-  it "adding comments" do
+  it 'adding comments' do
     visit spree.comments_admin_order_path(order)
     expect(page).to have_text(/No Comments found/i)
 
     fill_in 'Comment', with: 'A test comment.'
     click_button 'Add Comment'
 
-    expect(page).to have_text(/Comments \(1\)/i) # uppercase < v1.2, sentence case >= v1.3
+    # uppercase < v1.2, sentence case >= v1.3
+    expect(page).to have_text(/Comments \(1\)/i)
     expect(page).to have_text('A test comment.')
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,15 @@
-ENV["RAILS_ENV"] ||= "test"
+ENV['RAILS_ENV'] ||= 'test'
 
-require File.expand_path("../dummy/config/environment.rb", __FILE__)
+require File.expand_path('../dummy/config/environment.rb', __FILE__)
+require 'solidus_support/extension/feature_helper'
 
-require "solidus_support/extension/feature_helper"
-
-Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
+Dir[File.join(File.dirname(__FILE__), 'support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.raise_errors_for_deprecations!
 
-  config.example_status_persistence_file_path = "./spec/examples.txt"
+  config.example_status_persistence_file_path = './spec/examples.txt'
 
   config.include FeatureHelper, type: :feature
 end


### PR DESCRIPTION
We should only display the comment form if the user has permissions
to comment on the commentable object.