### PR TITLE
Fix comment_type being a required association on Spree::Comment

### DIFF
--- a/app/models/spree/comment.rb
+++ b/app/models/spree/comment.rb
@@ -2,10 +2,10 @@ class Spree::Comment < ActiveRecord::Base
   include ActsAsCommentable::Comment
 
   belongs_to :commentable, :polymorphic => true
-  belongs_to :comment_type
+  belongs_to :comment_type, optional: true
 
   default_scope { order('created_at ASC') }
-  
+
   # NOTE: install the acts_as_votable plugin if you
   # want user to vote on the quality of comments.
   #acts_as_voteable


### PR DESCRIPTION
comment_type is optional, but Rails 5+ validates the presence of belongs_to associations by default.