### PR TITLE
Improve Spree::Comment validation

### DIFF
--- a/app/controllers/spree/admin/comments_controller.rb
+++ b/app/controllers/spree/admin/comments_controller.rb
@@ -5,6 +5,11 @@ module Spree
     class CommentsController < Spree::Admin::ResourceController
       private
 
+      def render_after_create_error
+        flash.keep
+        redirect_to request.referer
+      end
+
       def location_after_save
         request.referer
       end

--- a/app/models/spree/comment.rb
+++ b/app/models/spree/comment.rb
@@ -15,5 +15,7 @@ module Spree
 
     # NOTE: Comments belong to a user
     belongs_to :user
+
+    validates :comment, presence: true
   end
 end

--- a/lib/solidus_comments/testing_support/factories.rb
+++ b/lib/solidus_comments/testing_support/factories.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :comment, class: Spree::Comment do
+    association :commentable, factory: :order
+    user
+    sequence(:comment) { |n| "Comment #{n}" }
+  end
 end

--- a/solidus_comments.gemspec
+++ b/solidus_comments.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'solidus_support', '~> 0.5'
 
   s.add_development_dependency 'solidus_dev_support'
+  s.add_development_dependency 'shoulda-matchers', '~> 4.0'
 end

--- a/spec/features/admin/order_comments_spec.rb
+++ b/spec/features/admin/order_comments_spec.rb
@@ -8,9 +8,12 @@ RSpec.describe 'Order Comments', :js do
     login_as_admin
   end
 
-  it 'adding comments' do
+  it 'adding comments to an order' do
     visit spree.comments_admin_order_path(order)
     expect(page).to have_text(/No Comments found/i)
+
+    click_button 'Add Comment'
+    expect(page).to have_text('Comment can\'t be blank')
 
     fill_in 'Comment', with: 'A test comment.'
     click_button 'Add Comment'

--- a/spec/model/comment_spec.rb
+++ b/spec/model/comment_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Spree::Comment, type: :model do
+  it 'has a valid factory' do
+    expect(build_stubbed(:comment)).to be_valid
+  end
+
+  it 'validates comment presence' do
+    expect(build_stubbed(:comment)).to validate_presence_of(:comment)
+  end
+end

--- a/spec/support/shoulda.rb
+++ b/spec/support/shoulda.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'shoulda-matchers'
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
This PR adds a simple presence validation for the `comment` `Spree::Comment` attribute.

Bundled together, this adds a couple of model specs.