### PR TITLE
Add 'word-break: break-word;' to comment style

### DIFF
--- a/app/views/spree/admin/shared/_comment_list.html.erb
+++ b/app/views/spree/admin/shared/_comment_list.html.erb
@@ -19,7 +19,7 @@
         <td class='align-center'><%= pretty_time(comment.created_at) %></td>
         <td class='align-center'><%= comment.comment_type.try(:name) || I18n.t('spree.none') %></td>
         <td class='align-center'><%= comment.user.try(:email) %></td>
-        <td><%= comment.comment.html_safe %></td>
+        <td style="word-break: break-word;"><%= comment.comment.html_safe %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
When a long link is added in comments, it is allowed to overflow its `<td />` container.

![Screenshot 2022-03-09 at 10 28 14](https://user-images.githubusercontent.com/1634023/157413580-fe14961c-e193-4673-8ed8-884fe6a3496f.png)

This tiny PR adds a sliver of inline CSS to make sure that links can break and be contained inside the `<td />`.

![Screenshot 2022-03-09 at 10 27 21](https://user-images.githubusercontent.com/1634023/157413615-6da29cd9-f5a9-4e8b-bafd-f1a820b3b150.png)