### PR TITLE
Rails 6 Ruby 3

### DIFF
--- a/solidus_comments.gemspec
+++ b/solidus_comments.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'acts_as_commentable', '~> 4.0'
+  s.add_dependency 'acts_as_commentable', '>= 4.0'
   s.add_dependency 'deface', '~> 1.5'
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_backend', ['>= 2.0.0', '< 4']


### PR DESCRIPTION
Loosen up acts_as_commentable dependency to be able to update to a Rails 6 fork